### PR TITLE
interop.js is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ import 'package:google_maps/google_maps.dart';
 
 ```html
 <script src="packages/browser/dart.js"></script>
-<script src="packages/browser/interop.js"></script>
 ```
 
 A very [simple example](example/01-basics/map-simple) :


### PR DESCRIPTION
```<script src="packages/browser/interop.js"> is no longer needed for dart:js. See http://pub.dartlang.org/packages/browser. interop.js:7```