### PR TITLE
upgrade to func 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/a14n/dart-google-maps
 environment:
   sdk: '>=1.21.0 <2.0.0'
 dependencies:
-  func: ^0.1.0
+  func: ^1.0.0
   js_wrapping: ^0.4.2
   meta: ^1.0.3
 dev_dependencies:


### PR DESCRIPTION
I think this is safe to upgrade; but the `func` package doesn't have a changelog.  I'm still in the process of testing.