### PR TITLE
Use covariant instead of `@checked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# v3.2.4 (2018-04-11)
+
+- Fix another issue with Dart-2
+
 # v3.2.3 (2018-04-07)
 
 - Fix some issue with Dart-2

--- a/lib/src/core/map_types/map_type_registry.dart
+++ b/lib/src/core/map_types/map_type_registry.dart
@@ -18,5 +18,5 @@ part of google_maps.src;
 abstract class _MapTypeRegistry extends MVCObject {
   factory _MapTypeRegistry() => null;
 
-  void set(String id, @checked MapType mapType);
+  void set(String id, covariant MapType mapType);
 }

--- a/lib/src/google_maps_src.dart
+++ b/lib/src/google_maps_src.dart
@@ -19,7 +19,6 @@ import 'dart:collection' show MapMixin;
 import 'dart:html' show Node, Document;
 
 import 'package:js_wrapping/js_wrapping.dart';
-import 'package:meta/meta.dart' show checked;
 
 import 'package:google_maps/util/async.dart';
 
@@ -204,7 +203,7 @@ abstract class _Controls extends JsInterface
     with MapMixin<ControlPosition, MVCArray<Node>> {
   _Controls() : super.created(new JsArray());
 
-  MVCArray<Node> operator [](@checked ControlPosition controlPosition) {
+  MVCArray<Node> operator [](covariant ControlPosition controlPosition) {
     var value = asJsObject(this)[_toJsControlPosition(controlPosition)];
     if (value == null) return null;
     return new MVCArray<Node>.created(value as JsObject);

--- a/lib/src/google_maps_src.g.dart
+++ b/lib/src/google_maps_src.g.dart
@@ -12,7 +12,7 @@ class Controls extends JsInterface
   Controls.created(JsObject o) : super.created(o);
   Controls() : super.created(new JsArray());
 
-  MVCArray<Node> operator [](@checked ControlPosition controlPosition) {
+  MVCArray<Node> operator [](covariant ControlPosition controlPosition) {
     var value = asJsObject(this)[_toJsControlPosition(controlPosition)];
     if (value == null) return null;
     return new MVCArray<Node>.created(value as JsObject);
@@ -5487,7 +5487,7 @@ class MapTypeRegistry extends MVCObject {
       : this.created(
             new JsObject(context['google']['maps']['MapTypeRegistry']));
 
-  void set(String id, @checked MapType mapType) {
+  void set(String id, covariant MapType mapType) {
     asJsObject(this).callMethod('set', [id, __codec129.encode(mapType)]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_maps
-version: 3.2.3
+version: 3.2.4
 author: Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
 description: With that package you will be able to use Google Maps JavaScript API from Dart scripts.
 homepage: https://github.com/a14n/dart-google-maps


### PR DESCRIPTION
For context: we are making progress towards enabling Dart-2 in dart2js. Dart2js uses the new common front-end which doesn't understand the `@checked` annotation, but does understand the `covariant` keyword.