### PR TITLE
Property className in MarkerLabel

### DIFF
--- a/lib/src/core/overlays/marker_label.dart
+++ b/lib/src/core/overlays/marker_label.dart
@@ -18,6 +18,7 @@ part of google_maps.src;
 abstract class _MarkerLabel implements JsInterface {
   factory _MarkerLabel() => null;
 
+  String className;
   String color;
   String fontFamily;
   String fontSize;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: google_maps
-version: 3.4.5
+version: 3.4.6
 description: >
   With that package you will be able to use Google Maps JavaScript API from Dart
   scripts.


### PR DESCRIPTION
Is it possible to release v3.4.6 with property `className` in `MarkerLabel`? Unfortunately I cannot utilise v4.0.0 because of using extensions for most classes what makes it impossible to inherit from them.