### PR TITLE
Support package:web ^0.5.0

### DIFF
--- a/example/01-basics/map-geolocation/page.dart
+++ b/example/01-basics/map-geolocation/page.dart
@@ -1,7 +1,7 @@
 import 'dart:js_interop';
 
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 late InfoWindow infoWindow;

--- a/example/03-controls/control-custom-state/page.dart
+++ b/example/03-controls/control-custom-state/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 final LatLng chicago = LatLng(41.85, -87.65);

--- a/example/03-controls/control-replacement/page.dart
+++ b/example/03-controls/control-replacement/page.dart
@@ -1,3 +1,5 @@
+import 'dart:js_interop';
+
 import 'package:google_maps/google_maps.dart' hide Event;
 import 'package:web/web.dart';
 
@@ -66,12 +68,31 @@ void initFullscreenControl(GMap map) {
   });
 }
 
-bool isFullscreen(Element element) => document.fullscreenElement == element;
+bool isFullscreen(Element element) =>
+    _FullscreenDocument(document).fullscreenElement == element;
 
 void requestFullscreen(Element element) {
-  element.requestFullscreen();
+  _FullscreenElement(element).requestFullscreen.callAsFunction();
 }
 
 void exitFullscreen() {
-  document.exitFullscreen();
+  _FullscreenDocument(document).exitFullscreen.callAsFunction();
+}
+
+/// This extension type merely exists because `package:web` no longer provides the Fullscreen API,
+/// as Safari only supports it under a prefix.
+///
+/// This extension type can be removed when that restriction is lifted.
+extension type _FullscreenDocument(Document _) {
+  external JSFunction get exitFullscreen;
+
+  external Element? get fullscreenElement;
+}
+
+/// This extension type merely exists because `package:web` no longer provides the Fullscreen API,
+/// as Safari only supports it under a prefix.
+///
+/// This extension type can be removed when that restriction is lifted.
+extension type _FullscreenElement(Element _) {
+  external JSFunction get requestFullscreen;
 }

--- a/example/03-controls/control-replacement/page.dart
+++ b/example/03-controls/control-replacement/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart' hide Event;
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 void main() {
   final map = GMap(
@@ -28,7 +28,7 @@ void initZoomControl(GMap map) {
 
 void initMapTypeControl(GMap map) {
   final mapTypeControlDiv =
-      document.querySelector('.maptype-control') as HtmlElement;
+      document.querySelector('.maptype-control') as HTMLElement;
 
   document.querySelector('.maptype-control-map')!.onClick.listen((event) {
     mapTypeControlDiv.classList.add('maptype-control-is-map');

--- a/example/03-controls/split-map-panes/page.dart
+++ b/example/03-controls/split-map-panes/page.dart
@@ -3,7 +3,7 @@ library example;
 
 import 'package:google_maps/google_maps.dart';
 import 'package:js/js.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 void main() {
   final mapOptions = MapOptions()

--- a/example/05-drawing_on_map/marker-animations-iteration/page.dart
+++ b/example/05-drawing_on_map/marker-animations-iteration/page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart' hide Animation;
+import 'package:web/web.dart' hide Animation;
 
 final berlin = LatLng(52.520816, 13.410186);
 final List<LatLng> neighborhoods = [

--- a/example/05-drawing_on_map/marker-remove/page.dart
+++ b/example/05-drawing_on_map/marker-remove/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 final markers = <Marker>[];

--- a/example/05-drawing_on_map/overlay-hideshow/page.dart
+++ b/example/05-drawing_on_map/overlay-hideshow/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late USGSOverlay overlay;
 

--- a/example/05-drawing_on_map/overlay-remove/page.dart
+++ b/example/05-drawing_on_map/overlay-remove/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GroundOverlay historicalOverlay;
 late GMap map;

--- a/example/05-drawing_on_map/polyline-remove/page.dart
+++ b/example/05-drawing_on_map/polyline-remove/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late Polyline flightPath;
 late GMap map;

--- a/example/06-layers/layer-data-dragndrop/page.dart
+++ b/example/06-layers/layer-data-dragndrop/page.dart
@@ -3,7 +3,7 @@ import 'dart:js_interop';
 
 import 'package:google_maps/google_maps.dart';
 import 'package:js/js_util.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 

--- a/example/06-layers/layer-heatmap/page.dart
+++ b/example/06-layers/layer-heatmap/page.dart
@@ -1,6 +1,6 @@
 import 'package:google_maps/google_maps.dart';
 import 'package:google_maps/google_maps_visualization.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 // Adding 500 Data Points
 late GMap map;
@@ -17,16 +17,16 @@ void main() {
     ..data = points
     ..map = map);
 
-  querySelector('#toggleHeatmap')!.onClick.listen((e) {
+  document.querySelector('#toggleHeatmap')!.onClick.listen((e) {
     toggleHeatmap();
   });
-  querySelector('#changeGradient')!.onClick.listen((e) {
+  document.querySelector('#changeGradient')!.onClick.listen((e) {
     changeGradient();
   });
-  querySelector('#changeRadius')!.onClick.listen((e) {
+  document.querySelector('#changeRadius')!.onClick.listen((e) {
     changeRadius();
   });
-  querySelector('#changeOpacity')!.onClick.listen((e) {
+  document.querySelector('#changeOpacity')!.onClick.listen((e) {
     changeOpacity();
   });
 }

--- a/example/07-maptypes/aerial-rotation/page.dart
+++ b/example/07-maptypes/aerial-rotation/page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 

--- a/example/08-services/directions-complex/page.dart
+++ b/example/08-services/directions-complex/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 late DirectionsRenderer directionsDisplay;
@@ -51,7 +51,7 @@ void calcRoute() {
   // function to create markers for each step.
   directionsService.route(request, (response, status) {
     if (status == DirectionsStatus.OK) {
-      querySelector('#warnings_panel')!.innerHTML =
+      document.querySelector('#warnings_panel')!.innerHTML =
           '<b>${response!.routes![0]!.warnings}</b>';
       directionsDisplay.directions = response;
       showSteps(response);

--- a/example/08-services/directions-panel/page.dart
+++ b/example/08-services/directions-panel/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late DirectionsRenderer directionsDisplay;
 final directionsService = DirectionsService();

--- a/example/08-services/directions-simple/page.dart
+++ b/example/08-services/directions-simple/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late DirectionsRenderer directionsDisplay;
 final directionsService = DirectionsService();

--- a/example/08-services/directions-travel-modes/page.dart
+++ b/example/08-services/directions-travel-modes/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late DirectionsRenderer directionsDisplay;
 final directionsService = DirectionsService();

--- a/example/08-services/directions-waypoints/page.dart
+++ b/example/08-services/directions-waypoints/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late DirectionsRenderer directionsDisplay;
 final directionsService = DirectionsService();
@@ -14,7 +14,7 @@ void main() {
   map = GMap(document.getElementById('map-canvas') as HTMLElement, mapOptions);
   directionsDisplay.map = map;
 
-  querySelector('#calcRoute')!.onClick.listen((e) => calcRoute());
+  document.querySelector('#calcRoute')!.onClick.listen((e) => calcRoute());
 }
 
 void calcRoute() {

--- a/example/08-services/distance-matrix/page.dart
+++ b/example/08-services/distance-matrix/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 late Geocoder geocoder;

--- a/example/08-services/elevation-paths/page.dart
+++ b/example/08-services/elevation-paths/page.dart
@@ -5,7 +5,7 @@ import 'dart:js_util';
 
 import 'package:google_maps/google_maps.dart';
 import 'package:js/js.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 @JS('google.visualization.ColumnChart')
 class ColumnChart {
@@ -107,7 +107,8 @@ void plotElevation(List<ElevationResult?>? results, ElevationStatus? status) {
     }
 
     // Draw the chart using the data within its DIV.
-    (querySelector('#elevation_chart')! as HTMLElement).style.display = 'block';
+    (document.querySelector('#elevation_chart')! as HTMLElement).style.display =
+        'block';
     chart.draw(data,
         jsify({'height': 150, 'legend': 'none', 'titleY': 'Elevation (m)'}));
   }

--- a/example/08-services/geocoding-reverse/page.dart
+++ b/example/08-services/geocoding-reverse/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 final geocoder = Geocoder();
 late GMap map;

--- a/example/08-services/geocoding-simple/page.dart
+++ b/example/08-services/geocoding-simple/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 final geocoder = Geocoder();
 late GMap map;

--- a/example/08-services/streetview-overlays/page.dart
+++ b/example/08-services/streetview-overlays/page.dart
@@ -1,5 +1,5 @@
 import 'package:google_maps/google_maps.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 late StreetViewPanorama panorama;
@@ -46,7 +46,10 @@ void main() {
       ..heading = 265
       ..pitch = 0);
 
-  querySelector('#toggleStreetView')!.onClick.listen((e) => toggleStreetView());
+  document
+      .querySelector('#toggleStreetView')!
+      .onClick
+      .listen((e) => toggleStreetView());
 }
 
 void toggleStreetView() {

--- a/example/10-places/place-search-pagination/page.dart
+++ b/example/10-places/place-search-pagination/page.dart
@@ -1,6 +1,6 @@
 import 'package:google_maps/google_maps.dart';
 import 'package:google_maps/google_maps_places.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late GMap map;
 

--- a/example/10-places/places-autocomplete-addressform/page.dart
+++ b/example/10-places/places-autocomplete-addressform/page.dart
@@ -4,7 +4,7 @@ import 'dart:js_util';
 
 import 'package:google_maps/google_maps.dart';
 import 'package:google_maps/google_maps_places.dart';
-import 'package:web/helpers.dart';
+import 'package:web/web.dart';
 
 late Autocomplete autocomplete;
 final componentForm = <String, String>{

--- a/example/10-places/places-autocomplete-hotelsearch/page.dart
+++ b/example/10-places/places-autocomplete-hotelsearch/page.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:google_maps/google_maps.dart';
 import 'package:google_maps/google_maps_places.dart';
-import 'package:web/helpers.dart' hide Animation, Event;
+import 'package:web/web.dart' hide Animation, Event;
 
 late GMap map;
 late PlacesService places;

--- a/example/10-places/places-autocomplete/page.dart
+++ b/example/10-places/places-autocomplete/page.dart
@@ -1,6 +1,6 @@
 import 'package:google_maps/google_maps.dart';
 import 'package:google_maps/google_maps_places.dart';
-import 'package:web/helpers.dart' hide Event;
+import 'package:web/web.dart' hide Event;
 
 void main() {
   final mapOptions = MapOptions()
@@ -69,7 +69,7 @@ void main() {
   // Sets a listener on a radio button to change the filter type on Places
   // Autocomplete.
   void setupClickListener(String id, List<String> types) {
-    final radioButton = querySelector('#$id');
+    final radioButton = document.querySelector('#$id');
     Event.addDomListener(radioButton, 'click', (_) {
       autocomplete.types = types;
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: google_maps
-version: 7.0.0
+version: 7.1.0
 description: >
   With that package you will be able to use Google Maps JavaScript API from Dart
   scripts.
 homepage: https://github.com/a14n/dart-google-maps
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 dependencies:
   js: ^0.6.3
   js_wrapping: ^0.7.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   js: ^0.6.3
   js_wrapping: ^0.7.4
   meta: ^1.3.0
-  web: ^0.4.0
+  web: ^0.5.0
 dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0


### PR DESCRIPTION
This PR updates google_maps to support the new release of package:web

- update `package:web/helpers.dart` import to `package:web/web.dart`
- `document.querySelector()` instead of the deprecated `querySelector()`
- since `package:web` no longer exports bindings for non-standard API's, I've opted to patch it with an extension type, which required a bump to Dart 3.3.

See https://github.com/dart-lang/web/blob/main/CHANGELOG.md#050

```
Currently, the API needs to be standards-track, and be supported by Safari, Chrome, and Firefox.
```

Context: https://github.com/flutter/packages/pull/5254#discussion_r1495188143