### PR TITLE
Allow package `web: ^1.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 8.0.0-dev.3
 
-- update package:web ^1.0.0
+- allow package:web ^1.0.0
 
 # 8.0.0-dev.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.0.0-dev.3
+
+- update package:web ^1.0.0
+
 # 8.0.0-dev.2
 
 - some minor changes

--- a/README-dev.md
+++ b/README-dev.md
@@ -10,6 +10,6 @@ There are 2 steps:
 2. Generate real code with [js_wrapping_generator](https://pub.dev/packages/js_wrapping_generator)
 
 ```
-dart --no-sound-null-safety tool/generate_lib.dart
+dart tool/generate_lib.dart
 dart run build_runner build --delete-conflicting-outputs -v lib
 ```

--- a/example/directions-complex/page.dart
+++ b/example/directions-complex/page.dart
@@ -53,7 +53,7 @@ void calcRoute() async {
   // function to create markers for each step.
   final response = await directionsService.route(request);
   document.querySelector('#warnings_panel')!.innerHTML =
-      '<b>${response.routes[0].warnings}</b>';
+      '<b>${response.routes[0].warnings}</b>'.toJS;
   directionsDisplay.directions = response;
   showSteps(response);
 }

--- a/example/directions-waypoints/page.dart
+++ b/example/directions-waypoints/page.dart
@@ -55,5 +55,5 @@ void calcRoute() async {
       ..write('${leg.endAddress}<br>')
       ..write('${leg.distance!.text}<br><br>');
   }
-  summaryPanel!.innerHTML = html.toString();
+  summaryPanel!.innerHTML = html.toString().toJS;
 }

--- a/example/distance-matrix/page.dart
+++ b/example/distance-matrix/page.dart
@@ -56,7 +56,7 @@ void calculateDistances() async {
           '${origins[i]} to ${destinations[j]}: ${results[j].distance.text} in ${results[j].duration.text}<br>');
     }
   }
-  document.getElementById('outputDiv')!.innerHTML = html.toString();
+  document.getElementById('outputDiv')!.innerHTML = html.toString().toJS;
 }
 
 void addMarker(String location, {required bool isDestination}) async {

--- a/example/places-autocomplete-hotelsearch/page.dart
+++ b/example/places-autocomplete-hotelsearch/page.dart
@@ -193,9 +193,9 @@ void Function(MapMouseEvent) showInfoWindow(
 // Load the place information into the HTML elements used by the info window.
 void buildIWContent(PlaceResult place) {
   document.getElementById('iw-icon')!.innerHTML =
-      '<img class="hotelIcon" src="${place.icon}"></img>';
+      '<img class="hotelIcon" src="${place.icon}"></img>'.toJS;
   document.getElementById('iw-url')!.innerHTML =
-      '<b><a href="${place.url}">${place.name}</a></b>';
+      '<b><a href="${place.url}">${place.name}</a></b>'.toJS;
   document.getElementById('iw-address')!.textContent = place.vicinity;
 
   if (place.formattedPhoneNumber != null) {
@@ -221,7 +221,7 @@ void buildIWContent(PlaceResult place) {
       }
       (document.getElementById('iw-rating-row')! as HTMLElement).style.display =
           '';
-      document.getElementById('iw-rating')!.innerHTML = ratingHtml;
+      document.getElementById('iw-rating')!.innerHTML = ratingHtml.toJS;
     }
   } else {
     (document.getElementById('iw-rating-row')! as HTMLElement).style.display =

--- a/example/places-queryprediction/page.dart
+++ b/example/places-queryprediction/page.dart
@@ -27,6 +27,6 @@ void callback(
 
   for (final prediction in predictions!.toDart) {
     results.innerHTML =
-        '${results.innerHTML}<li>${prediction!.description}</li>';
+        '${results.innerHTML}<li>${prediction!.description}</li>'.toJS;
   }
 }

--- a/example/streetview-event/page.dart
+++ b/example/streetview-event/page.dart
@@ -16,7 +16,7 @@ void main() {
   );
 
   panorama.onPanoChanged.listen((_) {
-    document.getElementById('pano_cell')!.innerHTML = panorama.pano;
+    document.getElementById('pano_cell')!.innerHTML = panorama.pano.toJS;
   });
 
   panorama.addListener(
@@ -30,15 +30,15 @@ void main() {
       final links = panorama.links;
       for (var i = 0; i < links.toDart.length; i++) {
         linksTable.insertRow()
-          ..insertCell().innerHTML = '<b>Link: $i</b>'
-          ..insertCell().innerHTML = links.toDart[i].description ?? '';
+          ..insertCell().innerHTML = '<b>Link: $i</b>'.toJS
+          ..insertCell().innerHTML = (links.toDart[i].description ?? '').toJS;
       }
     }.toJS,
   );
 
   panorama.onPositionChanged.listen((_) {
     document.getElementById('position_cell')!.innerHTML =
-        '${panorama.position}';
+        '${panorama.position}'.toJS;
   });
 
   panorama.onPovChanged.listen((_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.4.0
 dependencies:
   meta: ^1.3.0
-  web: ">=0.5.0 <2.0.0"
+  web: ">=0.5.1 <2.0.0"
 dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: google_maps
-version: 8.0.0-dev.2
+version: 8.0.0-dev.3
 description: >
   With that package you will be able to use Google Maps JavaScript API from Dart
   scripts.
 homepage: https://github.com/a14n/dart-google-maps
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: ^3.4.0
 dependencies:
   meta: ^1.3.0
-  web: ^0.5.0
+  web: ">=0.5.0 <2.0.0"
 dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0
   collection:
   html: ^0.15.0
-  http: ^0.13.0
+  http: ^1.2.2
   path: ^1.7.0
   petitparser: ^6.0.2


### PR DESCRIPTION
Hey @a14n!

I'm looking at updating `flutter/packages` to the latest major version of package:web, and I think I need a small change in `google_maps`: allowing web 1.0.0.

It seems the only other changes needed are to the examples, where the use of `innerHTML` has gone from `String` to `JSAny` (so Trusted Types are supported), but it seems the rest is all right.

I re-ran the build script(s) but nothing else seems to have changed:

```console
dit@dit:/work/a14n/google_maps$ dart --no-sound-null-safety tool/generate_lib.dart 
Setting VM flags failed: Unrecognized flags: sound_null_safety
dit@dit:/work/a14n/google_maps$ dart tool/generate_lib.dart 
dit@dit:/work/a14n/google_maps$ dart run build_runner build --delete-conflicting-outputs -v lib
Building package executable... (6.7s)
Built build_runner:build_runner.
[INFO] Entrypoint:Generating build script...
[INFO] Entrypoint:Generating build script completed, took 465ms

[INFO] Bootstrap:Precompiling build script......
[INFO] Bootstrap:Precompiling build script... completed, took 6.4s

[FINE] Bootstrap:Core package locations file does not exist
[INFO] BuildDefinition:Initializing inputs
[INFO] BuildDefinition:Building new asset graph...
[INFO] BuildDefinition:Building new asset graph completed, took 2.0s

[INFO] BuildDefinition:Checking for unexpected pre-existing outputs....
[INFO] BuildDefinition:Checking for unexpected pre-existing outputs. completed, took 0ms

[INFO] Build:Running build...
[INFO] Build:Running build completed, took 391ms

[INFO] Build:Caching finalized dependency graph...
[INFO] Build:Caching finalized dependency graph completed, took 304ms

[INFO] Build:Succeeded after 705ms with 0 outputs (2522 actions)
```

I've also updated the README-dev so it doesn't fail with the VM flags error, but that may be because I'm in a Dart SDK from the future (whatever is bundled with `flutter master`).

(As usual, thanks for the package!!)