### PR TITLE
Allow a range of package:web dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.4.0
 dependencies:
   meta: ^1.3.0
-  web: ^1.0.0
+  web: ">=0.5.1 <2.0.0"
 dev_dependencies:
   build_runner: ^2.4.0
   build_web_compilers: ^4.0.0


### PR DESCRIPTION
Revert "bump to web:^1.0.0"

This reverts commit 696b254341bc75a407d827c2835f55d961301959.
